### PR TITLE
update SDK integration, add tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.gitignore
+Dockerfile
+.dockerignore
+dist
+node_modules
+.env
+README.md

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -9,13 +9,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Test
+  api:
+    name: Test API
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: setup
+        run: docker compose up --quiet-pull --wait --wait-timeout 300
+      - name: hurl
+        run: docker compose run --quiet-pull integration-tests
+      - name: dump logs
+        run: docker compose logs
+        if: failure()
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: always()
         with:
-          node-version: 21
-      - name: build
-        run: npm ci
+          check_name: Results
+          report_paths: tests/api/report.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:lts-alpine AS builder
+USER node
+WORKDIR /opt/app
+COPY package*.json .
+RUN npm ci
+COPY --chown=node:node . .
+RUN npm run build && npm prune --omit=dev
+
+FROM node:lts-alpine
+
+ENV NODE_ENV production
+USER node
+WORKDIR /home/node
+
+COPY --from=builder --chown=node:node /opt/app/package*.json .
+COPY --from=builder --chown=node:node /opt/app/node_modules ./node_modules
+COPY --from=builder --chown=node:node /opt/app/dist ./dist
+
+# COPY package*.json .
+# COPY node_modules ./node_modules
+# COPY dist ./dist
+ARG PORT
+EXPOSE ${PORT:-3000}
+
+CMD ["node", "dist/main.js"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,39 @@
+services:
+  server:
+    build: .
+    environment:
+      - OPA_URL=http://opa:8181
+    depends_on:
+      - opa
+    expose:
+      - 3000
+
+  opa:
+    image: openpolicyagent/opa:latest
+    ports:
+      - '8181:8181'
+    command:
+      - run
+      - --server
+      - --addr=:8181
+      - --log-level=debug
+      - --bundle
+      - --disable-telemetry
+      - /policies
+    volumes:
+      - ./policies:/policies
+
+  integration-tests:
+    image: ghcr.io/orange-opensource/hurl:latest
+    volumes:
+      - ./tests:/tests:rw
+    entrypoint: sh
+    command:
+      - -c
+      - 'hurl --test --retry=10 --verbose --report-junit=tests/api/report.xml /tests/api/*.hurl'
+    environment:
+      - HURL_host=server:3000
+    depends_on:
+      - server
+    profiles:
+      - tools

--- a/src/authz/authz.service.ts
+++ b/src/authz/authz.service.ts
@@ -15,6 +15,6 @@ export class AuthzService {
     path: string,
     fromResult?: (_?: Result) => boolean,
   ): Promise<boolean> {
-    return await this.opa.authorize(path, inp, fromResult);
+    return await this.opa.evaluate(path, inp, { fromResult });
   }
 }

--- a/tests/api/basic.hurl
+++ b/tests/api/basic.hurl
@@ -1,54 +1,54 @@
-GET http://127.0.0.1:3000/hello
+GET http://{{host}}/hello
 Content-Type: application/json
 HTTP 200
 {"hello":"world"}
 
-POST http://127.0.0.1:3000/auth/login
+POST http://{{host}}/auth/login
 Content-Type: application/json
 {"username": "john", "password": "changeme"}
 HTTP 201
 [Captures]
 access_token: jsonpath "$['access_token']"
 
-GET http://127.0.0.1:3000/profile
+GET http://{{host}}/profile
 Content-Type: application/json
 Authorization: Bearer {{access_token}}
 HTTP 200
 {"id":1,"username":"john"}
 
-GET http://127.0.0.1:3000/cats
+GET http://{{host}}/cats
 Content-Type: application/json
 Authorization: Bearer {{access_token}}
 HTTP 200
 []
 
-POST http://127.0.0.1:3000/cats
+POST http://{{host}}/cats
 Content-Type: application/json
 Authorization: Bearer {{access_token}}
 {"name": "garfield", "age": 5, "breed": "unknown"}
 HTTP 403
 
 # Try as admin (maria)
-POST http://127.0.0.1:3000/auth/login
+POST http://{{host}}/auth/login
 Content-Type: application/json
 {"username": "maria", "password": "guess"}
 HTTP 201
 [Captures]
 access_token: jsonpath "$['access_token']"
 
-POST http://127.0.0.1:3000/cats
+POST http://{{host}}/cats
 Content-Type: application/json
 Authorization: Bearer {{access_token}}
 {"name": "garfield", "age": 5, "breed": "unknown"}
 HTTP 201
 
-GET http://127.0.0.1:3000/cats
+GET http://{{host}}/cats
 Content-Type: application/json
 Authorization: Bearer {{access_token}}
 HTTP 200
 [{"name":"garfield","age":5,"breed":"unknown"}]
 
-GET http://127.0.0.1:3000/cats/garfield
+GET http://{{host}}/cats/garfield
 Content-Type: application/json
 Authorization: Bearer {{access_token}}
 HTTP 200

--- a/tests/api/cats.hurl
+++ b/tests/api/cats.hurl
@@ -1,0 +1,19 @@
+POST http://{{host}}/auth/login
+Content-Type: application/json
+{"username": "maria", "password": "guess"}
+HTTP 201
+[Captures]
+access_token: jsonpath "$['access_token']"
+
+POST http://{{host}}/cats
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+{"name": "garfield", "age": 5, "breed": "unknown"}
+HTTP 201
+
+GET http://{{host}}/cats/garfield
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+x-user: stephan
+HTTP 200
+{"name":"garfield","age":5,"breed":"unknown"}

--- a/tests/api/report.xml
+++ b/tests/api/report.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite tests="2" errors="0" failures="0"><testcase id="/tests/api/basic.hurl" name="/tests/api/basic.hurl" time="0.135" /><testcase id="/tests/api/cats.hurl" name="/tests/api/cats.hurl" time="0.018" /></testsuite></testsuites>


### PR DESCRIPTION
This still neglects the nestjs/jest tests that the typescript-starter template gave us. Instead, we're building and starting the server, and query it's API via https://hurl.dev. 