### PR TITLE
ci: fix hurl integration tests

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
     entrypoint: sh
     command:
       - -c
-      - 'hurl --test --retry=10 --verbose --report-junit=tests/api/report.xml /tests/api/*.hurl'
+      - 'hurl --retry=10 --verbose --report-junit=tests/api/report.xml /tests/api/*.hurl'
     environment:
       - HURL_host=server:3000
     depends_on:

--- a/tests/api/report.xml
+++ b/tests/api/report.xml
@@ -1,1 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite tests="2" errors="0" failures="0"><testcase id="/tests/api/basic.hurl" name="/tests/api/basic.hurl" time="0.135" /><testcase id="/tests/api/cats.hurl" name="/tests/api/cats.hurl" time="0.018" /></testsuite></testsuites>


### PR DESCRIPTION
These weren't meant to be run in parallel, and hurl 5.0.0 started running everything in parallel if `--test` is used. So:

- stop using `--test`
- also remove `report.xml`, it has no place in our git index